### PR TITLE
Fixed a bug of HT, while using param of -a

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/HoeffdingTree.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/HoeffdingTree.scala
@@ -332,6 +332,7 @@ class HoeffdingTreeModel(val espec: ExampleSpecification, val numericObserverTyp
             case activeNode: ActiveLearningNode => {
               attemptToSplit(activeNode, foundNode.parent, foundNode.index)
             }
+            case other: Node=> {}
           }
         }
       }


### PR DESCRIPTION
for the foundNode.node match, the node might be other subclass of Node, if it is not SplitNode or ActiveLearningNode, do nothing.
add line case other:Node =>{}