### PR TITLE
Minor Changes to EvaluatePrequential

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
@@ -44,6 +44,10 @@ class BasicClassificationEvaluator extends Evaluator{
       .format((x._1+x._4)/(x._1+x._2+x._3+x._4),x._1,x._2,x._3,x._4)})
   }
 
+  override def header(): String = {
+    "Accuracy,TP,FN,FP,TN"
+  }
+
   /**
    * Get the evaluation result.
    *

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
@@ -37,6 +37,15 @@ abstract class Evaluator extends Configurable with Serializable{
   def addResult(input: DStream[(Example, Double)]):  DStream[String]
 
   /**
+    * Obtains the header definition
+    *
+    * @return a String representing the measurements header
+    */
+  def header(): String = {
+    ""
+  }
+
+  /**
    * Get the evaluation result.
    *
    * @return a Double containing the evaluation result

--- a/src/main/scala/org/apache/spark/streamdm/streams/PrintStreamWriter.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/PrintStreamWriter.scala
@@ -40,4 +40,10 @@ class PrintStreamWriter extends StreamWriter{
       rdd.foreach(x => {println(x)})
     })
   }
+
+  /**
+    * Prints a single line of text to the output only once.
+    * @param text
+    */
+  override def output(text: String) = println(text)
 }

--- a/src/main/scala/org/apache/spark/streamdm/streams/StreamWriter.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/StreamWriter.scala
@@ -30,4 +30,11 @@ abstract class StreamWriter extends Configurable {
    * @param stream a DStream of Strings for which the output is processed 
    */
   def output(stream: DStream[String]): Unit
+
+  /**
+    * Writes a single line on the output. Useful for writing one-time text, such as headers.
+    *
+    * @param text
+    */
+  def output(text: String): Unit
 }

--- a/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streamdm.tasks
 
-import com.github.javacliparser.{StringOption, ClassOption}
+import com.github.javacliparser.{ClassOption, FlagOption, StringOption}
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.classifiers._
 import org.apache.spark.streamdm.streams._
@@ -45,10 +45,13 @@ class EvaluatePrequential extends Task {
     "Evaluator to use", classOf[Evaluator], "BasicClassificationEvaluator")
 
   val streamReaderOption:ClassOption = new ClassOption("streamReader", 's',
-    "Stream reader to use", classOf[StreamReader], "FileReader")
+    "Stream reader to use", classOf[StreamReader], "org.apache.spark.streamdm.streams.generators.RandomTreeGenerator")
 
   val resultsWriterOption:ClassOption = new ClassOption("resultsWriter", 'w',
     "Stream writer to use", classOf[StreamWriter], "PrintStreamWriter")
+
+  val shouldPrintHeaderOption:FlagOption = new FlagOption("shouldPrintHeader", 'h',
+    "Whether or not to print the evaluator header on the output file")
 
   /**
    * Run the task.
@@ -66,6 +69,10 @@ class EvaluatePrequential extends Task {
     val writer:StreamWriter = this.resultsWriterOption.getValue()
 
     val instances = reader.getExamples(ssc)
+
+    if(shouldPrintHeaderOption.isSet) {
+      writer.output(evaluator.header())
+    }
 
     //Predict
     val predPairs = learner.predict(instances)


### PR DESCRIPTION
- Added an option to include a header to the output file
- Changed the default Stream Reader to RTG (a synthetic data stream). 
- Adding the header required changes to other classes, such as Evaluator, StreamWritter and BasicClassificationEvaluator

To test these changes:

This will run RTG with MultinomialNaiveBayes and output the header in log_RTG.txt
`./spark.sh "EvaluatePrequential -l (org.apache.spark.streamdm.classifiers.bayes.MultinomialNaiveBayes) -s (org.apache.spark.streamdm.streams.generators.RandomTreeGenerator) -h" 1> log_RTG.txt 2> error_RTG.txt`

Similar to the previous test, but this will yield the default (previous) approach: no header.
`./spark.sh "EvaluatePrequential -l (org.apache.spark.streamdm.classifiers.bayes.MultinomialNaiveBayes) -s (org.apache.spark.streamdm.streams.generators.RandomTreeGenerator)" 1> log_RTG.txt 2> error_RTG.txt`

This will use the new default stream reader, i.e., RTG
`./spark.sh "EvaluatePrequential -l (org.apache.spark.streamdm.classifiers.bayes.MultinomialNaiveBayes) -h" 1> log.txt 2> error.txt`