### PR TITLE
Changes in Statistics.scala to correctly compute statistics

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/utils/Statistics.scala
+++ b/src/main/scala/org/apache/spark/streamdm/utils/Statistics.scala
@@ -543,7 +543,7 @@ object Statistics {
 
   def polevl(x: Double, coef: Array[Double], N: Int): Double = {
     var ans = coef(0)
-    for (i <- 1 until N)
+    for (i <- 1 until N+1)
       ans = ans * x + coef(i)
     ans
   }


### PR DESCRIPTION
Mistakes in **polevl** (to compute Normal Probability; Statistics.scala) : loop until N, instead of N+1. 

This is to assure that StreamDM computes the exact Normal Distribution as in MOA. This Normal Distribution is used for Gaussian Estimation to compute the binarySplit in Numeric Features. (FeatureClassObserver.scala).

To make sure this change runnable, we could run the following test:
`./spark.sh "EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200) -s (FileReader -f ../data/iris.arff -k 1000 -d 10)" 1> result.res 2> log.log
`



