### PR TITLE
Update NominalFeatureObserver

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/FeatureClassObserver.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/FeatureClassObserver.scala
@@ -184,18 +184,18 @@ class NominalFeatureClassObserver(val numClasses: Int, val fIndex: Int, val numF
   override def bestSplit(criterion: SplitCriterion, pre: Array[Double],
     fValue: Double, isBinarySplit: Boolean): FeatureSplit = {
     var fSplit: FeatureSplit = null
-    for (i <- 0 until pre.length) {
+    if (!isBinarySplit) {
+      val post = multiwaySplit()
+      val merit = criterion.merit(pre, post)
+      fSplit = new FeatureSplit(new NominalMultiwayTest(fIndex, numFeatureValues), merit, post)
+    }
+
+    for (i <- 0 until numFeatureValues) {
       val post: Array[Array[Double]] = binarySplit(i)
       val merit = criterion.merit(normal(pre), normal(post))
       if (fSplit == null || fSplit.merit < merit) {
         fSplit = new FeatureSplit(new NominalBinaryTest(fIndex, i), merit, post)
       }
-    }
-    if (!isBinarySplit) {
-      val post = multiwaySplit()
-      val merit = criterion.merit(pre, post)
-      if (fSplit.merit < merit)
-        fSplit = new FeatureSplit(new NominalMultiwayTest(fIndex, numFeatureValues), merit, post)
     }
     fSplit
   }


### PR DESCRIPTION
There are two changes in this commit for function **bestSplit**, class **NominalFeatureClassObserver**, file **FeatureClassObserver.scala**
**1. Change the logic:** 
- Before: do the binarySplit first, then check if (binarySplit = false), create MultiwaySplit later.
- Now: check if (binarySplit = false) first, create MultiwaySplit; then do the binarySplit later.

Reason: Imitate logical structure of MOA in computing NominalFeatures: if binaryOnly is not turned on, then do the multiwaySplit first. 

**2. Iteration:**
- Before: Loop until pre.length (size of the pre-split distribution, which equals to the number of classes.  
- After: Loop until numFeatureValues    (number of values of that Nominal Feature)

Reason: 
This   is what MultiwaySplit should do:    
- For each value of NominalFeature,  compute the merit.   
- Compare all merits to select the best split.

-------------------
After having these two changes, NominalFeatureObserver could result in the same output (bestSplit with highest merit) for that Nominal Feature, as what MOA does.

--------------------

To test if this change is still runnable, we could run the following command: 

`./spark.sh   "EvaluatePrequential  -l   (trees.HoeffdingTree -l 0 -t 0.05 -g 200) -s (FileReader -f   ../data/randomtreesampledata -k 10 -d 10)"> result.res 2> log.log
--`








