### PR TITLE
Adding the calculation for precision, recall, fbeta-score, ...

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
@@ -57,10 +57,10 @@ class BasicClassificationEvaluator extends Evaluator{
     val recall = confMat{"tp"} / (confMat{"tp"}+confMat{"fn"})
     val precision = confMat{"tp"} / (confMat{"tp"}+confMat{"fp"})
     val specificity = confMat{"tn"} / (confMat{"tn"}+confMat{"fp"})
-    val f_beta_score = (1 + scala.math.pow(this.betaOption.getValue(),2)) * ((precision * recall) / ((scala.math.pow(this.betaOption.getValue(),2) * precision) + recall))
+    val f_beta_score = (1 + scala.math.pow(this.betaOption.getValue(),2)) * ((precision * recall) /
+      ((scala.math.pow(this.betaOption.getValue(),2) * precision) + recall))
 
-     "%.3f,%.3f,%.3f,%.3f,%.3f,%.0f,%.0f,%.0f,%.0f".format(
-        accuracy, recall, precision, f_beta_score, specificity,
+     "%.3f,%.3f,%.3f,%.3f,%.3f,%.0f,%.0f,%.0f,%.0f".format(accuracy, recall, precision, f_beta_score, specificity,
         confMat{"tp"}, confMat{"fn"}, confMat{"fp"}, confMat{"tn"})
   }
 

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
@@ -30,6 +30,7 @@ import org.apache.spark.streaming.dstream.DStream
 class BasicClassificationEvaluator extends Evaluator{
   var numInstancesCorrect = 0;
   var numInstancesSeen = 0;
+  var beta = 1.0;
 
   /**
    * Process the result of a predicted stream of Examples and Doubles.
@@ -38,14 +39,39 @@ class BasicClassificationEvaluator extends Evaluator{
    * @return a stream of String with the processed evaluation
    */
   override def addResult(input: DStream[(Example, Double)]): DStream[String] = {
-    //print the confusion matrix for each batch
-    val pred = ConfusionMatrix.computeMatrix(input)
-    pred.map(x => {"%.3f,%.0f,%.0f,%.0f,%.0f"
-      .format((x._1+x._4)/(x._1+x._2+x._3+x._4),x._1,x._2,x._3,x._4)})
+    val confusionMatrix = ConfusionMatrix.computeMatrix(input)
+    confusionMatrix.map(calculateMetrics)
+  }
+
+  /**
+    * Helper function to calculate several evaluation metrics based on a confusion matrix
+    * @param confMat
+    * @return
+    */
+  def calculateMetrics(confMat : Map[String,Double] ): String = {
+    val accuracy = (confMat{"tp"}+confMat{"tn"})/(confMat{"tp"}+confMat{"tn"}+confMat{"fp"}+confMat{"fn"})
+    val recall = confMat{"tp"} / (confMat{"tp"}+confMat{"fn"})
+    val precision = confMat{"tp"} / (confMat{"tp"}+confMat{"fp"})
+    val specificity = confMat{"tn"} / (confMat{"tn"}+confMat{"fp"})
+    val f_beta_score = (1 + scala.math.pow(this.beta,2)) * ((precision * recall) / ((scala.math.pow(this.beta,2) * precision) + recall))
+
+     "%.3f,%.3f,%.3f,%.3f,%.3f,%.0f,%.0f,%.0f,%.0f".format(
+        accuracy, recall, precision, f_beta_score, specificity,
+        confMat{"tp"}, confMat{"fn"}, confMat{"fp"}, confMat{"tn"})
   }
 
   override def header(): String = {
-    "Accuracy,TP,FN,FP,TN"
+    "Accuracy,Recall,Precision,F(beta=%.1f)-score,Specificity,TP,FN,FP,TN".format(this.beta)
+  }
+
+  /**
+    * Set the beta parameter for fbeta-score calculation. If it was not set, the default value is used beta = 1.0
+    * @param parameters
+    */
+  override def setParameters(parameters: Map[String, Double]): Unit = {
+    super.setParameters(parameters)
+    if(parameters.contains("beta"))
+      this.beta = parameters{"beta"}
   }
 
   /**
@@ -56,21 +82,25 @@ class BasicClassificationEvaluator extends Evaluator{
   override def getResult(): Double = 
     numInstancesCorrect.toDouble/numInstancesSeen.toDouble
 }
+
 /**
  * Helper class for computing the confusion matrix for binary classification.
  */
 object ConfusionMatrix extends Serializable{
   def confusion(x: (Example,Double)):
-  (Double, Double, Double, Double) = {
-    val a = if ((x._1.labelAt(0)==x._2)&&(x._2==0.0)) 1.0 else 0.0
-    val b = if ((x._1.labelAt(0)!=x._2)&&(x._2==0.0)) 1.0 else 0.0
-    val c = if ((x._1.labelAt(0)!=x._2)&&(x._2==1.0)) 1.0 else 0.0
-    val d = if ((x._1.labelAt(0)==x._2)&&(x._2==1.0)) 1.0 else 0.0
-    (a,b,c,d)
+  Map[String, Double] = {
+    val tp = if ((x._1.labelAt(0)==x._2)&&(x._2==0.0)) 1.0 else 0.0
+    val fn = if ((x._1.labelAt(0)!=x._2)&&(x._2==0.0)) 1.0 else 0.0
+    val fp = if ((x._1.labelAt(0)!=x._2)&&(x._2==1.0)) 1.0 else 0.0
+    val tn = if ((x._1.labelAt(0)==x._2)&&(x._2==1.0)) 1.0 else 0.0
+    Map("tp" -> tp, "fn" -> fn, "fp" -> fp, "tn" -> tn)
   }
 
   def computeMatrix(input: DStream[(Example,Double)]):
-  DStream[(Double,Double,Double,Double)] =
-    input.map(x=>confusion(x))
-      .reduce((x,y)=>(x._1+y._1,x._2+y._2,x._3+y._3,x._4+y._4))
+  DStream[Map[String, Double]] =
+      input.map(x => confusion(x)).reduce( (x,y) =>
+        Map("tp" -> (x{"tp"} + y{"tp"}),
+            "fn" -> (x{"fn"} + y{"fn"}),
+            "fp" -> (x{"fp"} + y{"fp"}),
+            "tn" -> (x{"tn"} + y{"tn"})))
 }

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
@@ -46,6 +46,14 @@ abstract class Evaluator extends Configurable with Serializable{
   }
 
   /**
+    * Allow passing parameters to the specific evaluator, such as beta from fbeta-score.
+    * @param parameters
+    */
+  def setParameters(parameters : Map[String, Double]): Unit = {
+
+  }
+
+  /**
    * Get the evaluation result.
    *
    * @return a Double containing the evaluation result

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
@@ -46,14 +46,6 @@ abstract class Evaluator extends Configurable with Serializable{
   }
 
   /**
-    * Allow passing parameters to the specific evaluator, such as beta from fbeta-score.
-    * @param parameters
-    */
-  def setParameters(parameters : Map[String, Double]): Unit = {
-
-  }
-
-  /**
    * Get the evaluation result.
    *
    * @return a Double containing the evaluation result

--- a/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streamdm.tasks
 
-import com.github.javacliparser.{ClassOption, FlagOption, StringOption}
+import com.github.javacliparser._
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.classifiers._
 import org.apache.spark.streamdm.streams._
@@ -53,6 +53,9 @@ class EvaluatePrequential extends Task {
   val shouldPrintHeaderOption:FlagOption = new FlagOption("shouldPrintHeader", 'h',
     "Whether or not to print the evaluator header on the output file")
 
+  val betaOption = new FloatOption("beta", 'b',
+    "Beta value for fbeta-score calculation.", 1.0, Double.MinValue, Double.MaxValue)
+
   /**
    * Run the task.
    * @param ssc The Spark Streaming context in which the task is run.
@@ -70,6 +73,8 @@ class EvaluatePrequential extends Task {
 
     val instances = reader.getExamples(ssc)
 
+    // It is important to set the evaluator parameters before invoking header() as they might influence the header.
+    evaluator.setParameters(Map({"beta" -> this.betaOption.getValue()}))
     if(shouldPrintHeaderOption.isSet) {
       writer.output(evaluator.header())
     }

--- a/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.streamdm.tasks
 
 import com.github.javacliparser._
-import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.classifiers._
 import org.apache.spark.streamdm.streams._
 import org.apache.spark.streaming.StreamingContext
@@ -42,7 +41,7 @@ class EvaluatePrequential extends Task {
     "Learner to use", classOf[Classifier], "SGDLearner")
 
   val evaluatorOption:ClassOption = new ClassOption("evaluator", 'e',
-    "Evaluator to use", classOf[Evaluator], "BasicClassificationEvaluator")
+    "Evaluator to use", classOf[Evaluator], "BasicClassificationEvaluator -b 1.0")
 
   val streamReaderOption:ClassOption = new ClassOption("streamReader", 's',
     "Stream reader to use", classOf[StreamReader], "org.apache.spark.streamdm.streams.generators.RandomTreeGenerator")
@@ -52,9 +51,6 @@ class EvaluatePrequential extends Task {
 
   val shouldPrintHeaderOption:FlagOption = new FlagOption("shouldPrintHeader", 'h',
     "Whether or not to print the evaluator header on the output file")
-
-  val betaOption = new FloatOption("beta", 'b',
-    "Beta value for fbeta-score calculation.", 1.0, Double.MinValue, Double.MaxValue)
 
   /**
    * Run the task.
@@ -73,8 +69,6 @@ class EvaluatePrequential extends Task {
 
     val instances = reader.getExamples(ssc)
 
-    // It is important to set the evaluator parameters before invoking header() as they might influence the header.
-    evaluator.setParameters(Map({"beta" -> this.betaOption.getValue()}))
     if(shouldPrintHeaderOption.isSet) {
       writer.output(evaluator.header())
     }

--- a/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
@@ -41,7 +41,7 @@ class EvaluatePrequential extends Task {
     "Learner to use", classOf[Classifier], "SGDLearner")
 
   val evaluatorOption:ClassOption = new ClassOption("evaluator", 'e',
-    "Evaluator to use", classOf[Evaluator], "BasicClassificationEvaluator -b 1.0")
+    "Evaluator to use", classOf[Evaluator], "BasicClassificationEvaluator")
 
   val streamReaderOption:ClassOption = new ClassOption("streamReader", 's',
     "Stream reader to use", classOf[StreamReader], "org.apache.spark.streamdm.streams.generators.RandomTreeGenerator")


### PR DESCRIPTION
This change includes the addition of precision, recall, specificity, and fbeta-score, to BasicClassificationEvaluator.scala. 
All these metrics are relevant for evaluating imbalanced classification problems. 

~It is possible to configure the beta value for fbeta-score in the EvaluatePrequential.scala (parameter -b), the way it is passed to BasicClassificationEvaluator is by using a generic dictionary of parameters. This approach can be used to pass specific parameters to Evaluators.scala descendants without disrupting the general interface.~
*The beta hyperparameter has been moved to BasicClassificationEvaluator. By doing that there is no need to include a dictionary of parameters or anything like that. The tests were updated as well.* 

The current version extends the existing metric calculation in BasicEvaluationPrequential, therefore it is based on a single confusion matrix and **so far it is not possible to properly evaluate multi-class problems**. 

A future adaptation to this BasicClassificationEvaluator should include a way to properly calculate the multi-class versions of the aforementioned metrics (e.g. using macro and micro average). 

Another small change within BasicClassificationEvaluator is that the internal representation of the confusion matrix was changed from a (Double, Double, Double, Double) to a Map[String, Double], therefore it is less likely to incorrectly use, for example, fn instead of fp as one have to explicitly state  something like `x{"fn"}` instead of `x._1`. 

**Tests**
* Using f0.5-score
`./spark.sh "EvaluatePrequential -l (org.apache.spark.streamdm.classifiers.bayes.MultinomialNaiveBayes) -e (BasicClassificationEvaluator -b 0.5) -h" 1> log_fbeta_05.txt 2> error.txt`

* Using f1.0-score (default configuration, no need to set -b)
`./spark.sh "EvaluatePrequential -l (org.apache.spark.streamdm.classifiers.bayes.MultinomialNaiveBayes) -h" 1> log_f1.txt 2> error.txt`

* Using f2-score
`./spark.sh "EvaluatePrequential -l (org.apache.spark.streamdm.classifiers.bayes.MultinomialNaiveBayes) -e (BasicClassificationEvaluator -b 2.0) -h" 1> log_fbeta_2.txt 2> error.txt`