### PR TITLE
update Gaussian Estimator and Entropy in SplitCriterion

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/GaussianEstimator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/GaussianEstimator.scala
@@ -171,7 +171,6 @@ class GaussianEstimator(var weightSum: Double = 0.0, var mean: Double = 0.0,
     //less than weights sum
     val lsWeight = {
       if (stdDev() > 0) {
-//        Statistics.normalProbability((splitValue - getMean()) / stdDev())
         Statistics.normalProbability((splitValue - getMean()) / stdDev()) * weightSum - eqWeight
       } else {
         if (splitValue < getMean()) weightSum - eqWeight

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/GaussianEstimator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/GaussianEstimator.scala
@@ -171,7 +171,8 @@ class GaussianEstimator(var weightSum: Double = 0.0, var mean: Double = 0.0,
     //less than weights sum
     val lsWeight = {
       if (stdDev() > 0) {
-        Statistics.normalProbability((splitValue - getMean()) / stdDev())
+//        Statistics.normalProbability((splitValue - getMean()) / stdDev())
+        Statistics.normalProbability((splitValue - getMean()) / stdDev()) * weightSum - eqWeight
       } else {
         if (splitValue < getMean()) weightSum - eqWeight
         else 0.0

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/SplitCriterion.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/SplitCriterion.scala
@@ -100,7 +100,9 @@ class InfoGainSplitCriterion extends SplitCriterion with Serializable {
    * @return the entropy
    */
   def entropy(pre: Array[Double]): Double = {
-    if (pre == null || pre.sum <= 0 || hasNegative(pre)) 0.0
+    if (pre == null || pre.sum <= 0 || hasNegative(pre)) {
+      0.0
+    }
     else {
       log2(pre.sum) - pre.filter(_ > 0).map(x => x * log2(x)).sum / pre.sum
     }

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/SplitCriterion.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/SplitCriterion.scala
@@ -101,7 +101,9 @@ class InfoGainSplitCriterion extends SplitCriterion with Serializable {
    */
   def entropy(pre: Array[Double]): Double = {
     if (pre == null || pre.sum <= 0 || hasNegative(pre)) 0.0
-    log2(pre.sum) - pre.filter(_ > 0).map(x => x * log2(x)).sum / pre.sum
+    else {
+      log2(pre.sum) - pre.filter(_ > 0).map(x => x * log2(x)).sum / pre.sum
+    }
   }
 
   /**
@@ -111,7 +113,7 @@ class InfoGainSplitCriterion extends SplitCriterion with Serializable {
    * @return the entropy
    */
   def entropy(post: Array[Array[Double]]): Double = {
-    if (post == null || post.length == 0 || post(0).length == 0) 0
+    if (post == null || post.length == 0 || post(0).length == 0) 0.0
     else {
       post.map { row => (row.sum * entropy(row)) }.sum / post.map(_.sum).sum
     }
@@ -121,7 +123,7 @@ class InfoGainSplitCriterion extends SplitCriterion with Serializable {
   /**
    * Returns number of subsets which have values greater than minFrac
    *
-   * @param post he matrix as an Array of Array
+   * @param post the matrix as an Array of Array
    * @param minFrac the min threshold
    * @return number of subsets
    */


### PR DESCRIPTION
This pull request has two small changes: update Gaussian Estimator, and Entropy in SplitCriterion

1. Update Gaussian Estimator: 
- Before : `Statistics.normalProbability((splitValue - getMean()) / stdDev())`
- Now: `Statistics.normalProbability((splitValue - getMean()) / stdDev()) * weightSum - eqWeight`

**Reason:** Imitate MOA's equation in computing weights for Gaussian Estimator

2. Entropy in SplitCriterion:
- Before: It doesn't simply return 0.0 if pre null, sum <=0 or hasNegative = true. It computes entropy anyway.
After: Add `else` clause. 

**Reason:** : Imitate MOA's equation.


Test for these changes: 

Run this command to make sure it's runnable: 
`./spark.sh "EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/electNormNew.arff -k 4000 -d 10)" 1> resu.res 2> log.log`