### PR TITLE
Update stream dm job - batchInterval is not hardcoded anymore

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
@@ -35,14 +35,15 @@ object streamDMJob {
     //configuration and initialization of model
     val conf = new SparkConf().setAppName("streamDM")
 
-    var newArgs = args.clone()
+    var paramsArgs = args.clone()
     var batchInterval: Int = 1000
     if(args.length > 0){
-      if(Try(args(0).toInt).isSuccess){
-        if(args(0).toInt > 0 && args(0).toInt < Int.MaxValue){
-          batchInterval = args(0).toInt
+      val firstArg = args(0)
+      if(Try(firstArg.toInt).isSuccess){
+        if(firstArg.toInt > 0 && firstArg.toInt < Int.MaxValue){
+          batchInterval = firstArg.toInt
         }
-        newArgs = newArgs.drop(1)
+        paramsArgs = paramsArgs.drop(1)
       }
     }
     println("BatchInterval: " + batchInterval + " ms")
@@ -50,7 +51,7 @@ object streamDMJob {
     val ssc = new StreamingContext(conf, Milliseconds(batchInterval))
 
     //run task
-    val string = if (newArgs.length > 0) newArgs.mkString(" ")
+    val string = if (paramsArgs.length > 0) paramsArgs.mkString(" ")
     else "EvaluatePrequential"
     val task:Task = ClassOption.cliStringToObject(string, classOf[Task], null)
     task.run(ssc)

--- a/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
@@ -34,9 +34,6 @@ object streamDMJob {
 
     //configuration and initialization of model
     val conf = new SparkConf().setAppName("streamDM")
-    //    conf.setMaster("local[2]")
-
-    // conf.setMaster("yarn")   //to run on clusters
 
     var newArgs = args.clone()
     var batchInterval: Int = 1000

--- a/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
@@ -42,7 +42,9 @@ object streamDMJob {
     var batchInterval: Int = 1000
     if(args.length > 0){
       if(Try(args(0).toInt).isSuccess){
-        batchInterval = args(0).toInt
+        if(args(0).toInt > 0 && args(0).toInt < Int.MaxValue){
+          batchInterval = args(0).toInt
+        }
         newArgs = newArgs.drop(1)
       }
     }


### PR DESCRIPTION
This pull request has one change in  **streamDMJob.scala**: 

**Change:**
- **batchInterval** is set by parameter from command line (arguments of spark program)
- This will process the list of arguments as follow: 
++ Check the first argument (args(0)) if it is an integer. If yes, check if it is >0 and < maxInt. If yes, set it as the **batchInterval**. Then _drop_ the first element of _args_
++ Pass the newArgs (args dropping the first element) to process in _Task_.
- **batchInterval** is now set by **Milliseconds** (before it was **Seconds**).
- Default value of batchInterval is 1000 ms.


 **Reason:**  User can set batchInterval from arguments. Because batchInterval needs to be _tuned a lot_ to help SparkStreaming program have a good performance, it _should not be hardcoded_.

**Test**: To verify this, you could run the following test: 

1. Test with batchInterval: 

`./spark.sh "200 EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/electNormNew.arff -k 4000 -d 10)" 1> result.res 2> log.log`

This sets batchInterval to be **200 ms**


2. Test with negative batchInterval:

`./spark.sh "-300 EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/electNormNew.arff -k 4000 -d 10)" 1> result.res 2> log.log`

This sets batchInterval to be default value = **1000 ms**

3. Test with no user-defined value: 
`./spark.sh "EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/electNormNew.arff -k 4000 -d 10)" 1> result.res 2> log.log`

This sets batchInterval to be default value = **1000 ms**