### PR TITLE
Update File Reader. Add limit instance as stopping condition

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/streams/FileReader.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/FileReader.scala
@@ -58,7 +58,7 @@ class FileReader extends StreamReader with Logging {
     "Type of the instance to use", "dense")
 
   val instanceLimitOption: IntOption = new IntOption("instanceLimit", 'i',
-    "Limit of number of instance", 100000,1, Integer.MAX_VALUE)
+    "Limit of number of instance", 100000, 1, Integer.MAX_VALUE)
 
   val fileNameOption: StringOption = new StringOption("fileName", 'f',
     "File Name", "../data/hyperplanesampledata")
@@ -124,9 +124,6 @@ class FileReader extends StreamReader with Logging {
     }
     // if reach the end of file, will go to the head again
     if (!lines.hasNext) {
-      println("=============================")
-      println("\t\tEnd of file!")
-      println("=============================")
       exp
     }
     var line = lines.next()


### PR DESCRIPTION
This pull request has 1 change in File Reader:

**Change**: 
- Add a parameter for limit number of instances `-i` in FileReader. 
- Stop Spark Context if the number of instances reaches the limit, by using `ssc.stop(stopSparkContext = false, stopGracefully = false)`

**Reason**: Stopping Condition, used for benchmarking (computing running time).

**Test**: 

We could run the code as follow: 

`./spark.sh   "200 EvaluatePrequential  -l   (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f   ../data/electNormNew.arff -k 4000 -d 10 -i 30000)"  1> result.res 2> log.log`

Here, we limit the number of instances to be `30000`