### PR TITLE
Adding multiclass evaluation metrics

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/core/DenseInstance.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/DenseInstance.scala
@@ -33,12 +33,13 @@ case class DenseInstance(inVector: Array[Double])
   val features = inVector
 
   /* Get the feature value present at position index
+  * In case the index does not exist or is invalid, then NaN is returned.
   *
   * @param index the index of the desired value 
   * @return a Double representing the feature value
   */
   override def apply(index: Int): Double =
-    if (index >= features.length || index < 0) 0.0 else features(index)
+    if (index >= features.length || index < 0) Double.NaN else features(index)
 
   /*
    * Return an array of features and indexes

--- a/src/main/scala/org/apache/spark/streamdm/core/SparseInstance.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/SparseInstance.scala
@@ -36,13 +36,14 @@ case class SparseInstance(inIndexes:Array[Int], inValues:Array[Double])
   val values = inValues
 
   /* Get the value present at position index
+  * In case the index does not exist or is invalid, then NaN is returned.
   *
   * @param index the index of the features
   * @return a Double representing the value, or 0.0 if not found
   */
   def apply(index: Int): Double = {
     var i: Int = 0
-    var value: Double = 0.0
+    var value: Double = Double.NaN
     var found = false
     while(i<indexes.length && !found) {
       if(indexes(i)==index) {

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
@@ -249,4 +249,8 @@ object ConfusionMatrixMultiClass extends Serializable {
   DStream[Map[(Int, Int), Double]] =
     input.map(x => confusion(x, numClasses)).reduce( (x,y) =>
       y ++ x.map{ case (k,v) => k -> (v + y.getOrElse(k,0.0))} )
+<<<<<<< HEAD
 }
+=======
+}
+>>>>>>> 269ee3921dcd00c41ad586c045a5df6dd1054f22

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
@@ -249,8 +249,4 @@ object ConfusionMatrixMultiClass extends Serializable {
   DStream[Map[(Int, Int), Double]] =
     input.map(x => confusion(x, numClasses)).reduce( (x,y) =>
       y ++ x.map{ case (k,v) => k -> (v + y.getOrElse(k,0.0))} )
-<<<<<<< HEAD
 }
-=======
-}
->>>>>>> 269ee3921dcd00c41ad586c045a5df6dd1054f22

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
@@ -19,40 +19,73 @@ package org.apache.spark.streamdm.evaluation
 
 import java.io.Serializable
 
+import com.github.javacliparser.FlagOption
+import org.apache.spark.Logging
+import org.apache.spark.streamdm.core.specification.ExampleSpecification
 import com.github.javacliparser.FloatOption
 import org.apache.spark.streamdm.core.Example
 import org.apache.spark.streaming.dstream.DStream
 
 /**
- * Single label binary classification evaluator which computes the confusion
- * matrix from a stream of tuples composed of testing Examples and doubles
- * predicted by the learners.
+ * The basic classification evaluator output metrics for both binary and
+ * multiclass problems.
+ * Input: testing Examples and doubles predicted by the learners.
+ * Output:
+ * (Binary) Accuracy, Recall, Precision, Fbeta-score,
+ * Specificity, Confusion Matrix
+ * (Multiclass) Accuracy, Recall-macro-avg, Precision-macro-avg,
+ * Fbeta-score-macro-avg, Per class recall and precision (Optional),
+ * Confusion Matrix (Optional)
+ *
+ * <p>It uses the following options:
+ * <ul>
+ *  <li> beta (<b>-b</b>), representing the beta value for f-score calculation
+ *  <li> supressPerClassMetrics (<b>-c</b>), when true prevent output of recall and precision per class
+ *  <li> supressConfusionMatrix (<b>-m</b>), when true prevent output of the confusion matrix
+ * </ul>
  */
-class BasicClassificationEvaluator extends Evaluator{
+class BasicClassificationEvaluator extends Evaluator with Logging {
 
   val betaOption = new FloatOption("beta", 'b',
     "Beta value for fbeta-score calculation.", 1.0, Double.MinValue, Double.MaxValue)
 
-  var numInstancesCorrect = 0;
-  var numInstancesSeen = 0;
+  val supressPerClassMetricsOption = new FlagOption("supressPerClassMetrics",
+    'c', "Do not output the per class precision and recall for multi-class problems.")
+
+  val supressConfusionMatrixOption = new FlagOption("supressConfusionMatrix",
+    'm', "Do not output the confusion matrix.")
+
+  override def setExampleSpecification(exampleSpecification: ExampleSpecification) = {
+    exampleLearnerSpecification = exampleSpecification
+  }
 
   /**
    * Process the result of a predicted stream of Examples and Doubles.
+   * The second value of the tuple (Double) contains the predicted value.
+   * The first value contain the original Example.
    *
    * @param input the input stream containing (Example,Double) tuples
    * @return a stream of String with the processed evaluation
    */
   override def addResult(input: DStream[(Example, Double)]): DStream[String] = {
-    val confusionMatrix = ConfusionMatrix.computeMatrix(input)
-    confusionMatrix.map(calculateMetrics)
+    val numClasses = exampleLearnerSpecification.outputFeatureSpecification(0).range
+    if(numClasses == 2) {
+      val confusionMatrix = ConfusionMatrix.computeMatrix(input)
+      confusionMatrix.map(calculateMetricsBinary)
+    }
+    else {
+      val confusionMatrixMultiClass = ConfusionMatrixMultiClass.computeMatrix(input, numClasses)
+      confusionMatrixMultiClass.map(calculateMetricsMultiClass)
+    }
   }
 
   /**
-    * Helper function to calculate several evaluation metrics based on a confusion matrix
-    * @param confMat
-    * @return
+    * Calculate several evaluation metrics for binary classification based
+    * on a confusion matrix
+    * @param confMat the binary confusion matrix
+    * @return one string containing the metrics
     */
-  def calculateMetrics(confMat : Map[String,Double] ): String = {
+  def calculateMetricsBinary(confMat : Map[String,Double] ): String = {
     val accuracy = (confMat{"tp"}+confMat{"tn"})/(confMat{"tp"}+confMat{"tn"}+confMat{"fp"}+confMat{"fn"})
     val recall = confMat{"tp"} / (confMat{"tp"}+confMat{"fn"})
     val precision = confMat{"tp"} / (confMat{"tp"}+confMat{"fp"})
@@ -64,23 +97,118 @@ class BasicClassificationEvaluator extends Evaluator{
         confMat{"tp"}, confMat{"fn"}, confMat{"fp"}, confMat{"tn"})
   }
 
-  override def header(): String = {
-    "Accuracy,Recall,Precision,F(beta=%.1f)-score,Specificity,TP,FN,FP,TN".format(this.betaOption.getValue())
+  /**
+    * Calculate several evaluation metrics for multiclass classification based
+    * on a confusion matrix
+    * @param confMat the multiclass confusion matrix
+    * @return one string containing the metrics
+    */
+  def calculateMetricsMultiClass(confMat : Map[(Int, Int), Double]): String = {
+    val numClasses = exampleLearnerSpecification.outputFeatureSpecification(0).range
+    val instancesSeenBatch = confMat.values.reduce(_+_)
+    val accuracy = confMat.filter(t => t._1._1 == t._1._2).values.reduce(_+_) / instancesSeenBatch
+    val recallPerClass = calculateRecallMultiClass(confMat)
+    val precisionPerClass = calculatePrecisionMultiClass(confMat)
+    // Ignore NaN values while calculating the macro average recall and precision.
+    val recallMacro = recallPerClass.filter(!_.isNaN()).reduce((v,k) => v + k) / (numClasses - recallPerClass.count(_.isNaN))
+    val precisionMacro = precisionPerClass.filter(!_.isNaN()).reduce((v,k) => v + k) / (numClasses - precisionPerClass.count(_.isNaN))
+    val squaredBeta = scala.math.pow(this.betaOption.getValue(),2)
+    // Avoid division by zero in fscore
+    val fscoreMacro = if ((squaredBeta * precisionMacro + recallMacro) != 0) ((squaredBeta +1) * precisionMacro * recallMacro) / (squaredBeta * precisionMacro + recallMacro) else 0.0
+
+    var output = "%.3f,%.3f,%.3f,%.3f,".format(accuracy, recallMacro, precisionMacro, fscoreMacro)
+
+    if(!this.supressPerClassMetricsOption.isSet()) {
+      val strRecallPerClass = recallPerClass.foldLeft("")((r : String, c : Double) => r+"%.4f,".format(c))
+      val strPrecisionPerClass = precisionPerClass.foldLeft("")((r : String, c : Double) => r+"%.4f,".format(c))
+      output += "%s%s".format(strRecallPerClass, strPrecisionPerClass)
+    }
+
+    if(!this.supressConfusionMatrixOption.isSet()) {
+      output += "%s".format(confMat.map( x => "(%d %d)=%.1f".format(x._1._1, x._1._2, x._2) ).mkString(","))
+    }
+    output
+  }
+
+  /***
+    * Calculates recall for each class label.
+    * @param confMat confusion matrix (predicted groundtruth) => instance counter
+    * @return array containing the recall for each class label
+    */
+  def calculateRecallMultiClass(confMat : Map[(Int, Int), Double]): Array[Double] = {
+    val numClasses = exampleLearnerSpecification.outputFeatureSpecification(0).range
+    var recallPerClassIndex = Array.fill(numClasses){0.0}
+
+    for(groundTruth <- Range(0, numClasses)) {
+      var TPi = 0.0
+      var FNi = 0.0
+      for(predicted <- Range(0, numClasses)) {
+        if(predicted == groundTruth) {
+          TPi += confMat( (predicted, groundTruth) )
+        }
+        else {
+          FNi += confMat( (predicted, groundTruth) )
+        }
+      }
+      recallPerClassIndex(groundTruth) = TPi / (TPi + FNi)
+    }
+    recallPerClassIndex
+  }
+
+  /***
+    * Calculates precision for each class label.
+    * @param confMat confusion matrix (predicted groundtruth) => instance counter
+    * @return array containing the precision for each class label
+    */
+  def calculatePrecisionMultiClass(confMat : Map[(Int, Int), Double]): Array[Double] = {
+    val numClasses = exampleLearnerSpecification.outputFeatureSpecification(0).range
+    var precisionPerClassIndex = Array.fill(numClasses){0.0}
+
+    for(predicted <- Range(0, numClasses)) {
+      var TPi = 0.0
+      var FPi = 0.0
+
+      for(groundTruth <- Range(0, numClasses)) {
+        if(predicted == groundTruth) {
+          TPi += confMat( (predicted, groundTruth) )
+        }
+        else {
+          FPi += confMat( (predicted, groundTruth) )
+        }
+      }
+      precisionPerClassIndex(predicted) = TPi / (TPi + FPi)
+    }
+    precisionPerClassIndex
   }
 
   /**
-   * Get the evaluation result.
-   *
-   * @return a Double containing the evaluation result
-   */
-  override def getResult(): Double = 
-    numInstancesCorrect.toDouble/numInstancesSeen.toDouble
+    * The header changes according to the number of classes.
+    * @return a String representing the measurements header
+    */
+  override def header(): String = {
+    val numClasses = exampleLearnerSpecification.outputFeatureSpecification(0).range
+    if(numClasses == 2) {
+      "Accuracy,Recall,Precision,F(beta=%.1f)-score,Specificity,TP,FN,FP,TN".format(this.betaOption.getValue())
+    }
+    else {
+      var output = "Accuracy,Recall-avg-macro,Precision-avg-macro,F(beta=%.1f)-score-avg-macro,".format(this.betaOption.getValue())
+      if(!this.supressPerClassMetricsOption.isSet()) {
+        val perClassRecall = Range(0, numClasses).foldLeft("")( (s,i) => s + "Recall(" + i + "),")
+        val perClassPrecision = Range(0, numClasses).foldLeft("")( (s,i) => s + "Precision(" + i + "),")
+        output += perClassRecall + perClassPrecision
+      }
+      if(!this.supressConfusionMatrixOption.isSet()) {
+        output += "ConfusionMatrix(predicted groundtruth)"
+      }
+      output
+    }
+  }
 }
 
 /**
  * Helper class for computing the confusion matrix for binary classification.
  */
-object ConfusionMatrix extends Serializable{
+object ConfusionMatrix extends Serializable with Logging {
   def confusion(x: (Example,Double)):
   Map[String, Double] = {
     val tp = if ((x._1.labelAt(0)==x._2)&&(x._2==0.0)) 1.0 else 0.0
@@ -97,4 +225,28 @@ object ConfusionMatrix extends Serializable{
             "fn" -> (x{"fn"} + y{"fn"}),
             "fp" -> (x{"fp"} + y{"fp"}),
             "tn" -> (x{"tn"} + y{"tn"})))
+}
+
+/**
+  * Helper class for computing the confusion matrix for multi-class classification.
+  */
+object ConfusionMatrixMultiClass extends Serializable {
+  def confusion(x: (Example,Double), numClasses: Int):
+  Map[(Int, Int), Double] = {
+    var outMat: Map[(Int, Int), Double] = Map()
+    for(predicted <- Range(0, numClasses)) {
+      for(groundTruth <- Range(0, numClasses)) {
+        if (x._2 == predicted && x._1.labelAt(0) == groundTruth)
+          outMat += (predicted, groundTruth) -> 1.0
+        else
+          outMat += (predicted, groundTruth) -> 0.0
+      }
+    }
+    outMat
+  }
+
+  def computeMatrix(input: DStream[(Example,Double)], numClasses: Int):
+  DStream[Map[(Int, Int), Double]] =
+    input.map(x => confusion(x, numClasses)).reduce( (x,y) =>
+      y ++ x.map{ case (k,v) => k -> (v + y.getOrElse(k,0.0))} )
 }

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/ClusteringEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/ClusteringEvaluator.scala
@@ -42,13 +42,6 @@ class ClusteringCohesionEvaluator extends Evaluator {
                     map{case (k,c,s) => (k,c)}
       inv.join(centr).map{case (k,(e,c))=>pow(e.in.distanceTo(c.in),2)}  
     }).reduce(_+_).map(x=>"SSE=%.5f".format(x))
-
-  /**
-   * Get the evaluation result.
-   *
-   * @return a Double containing the evaluation result
-   */ 
-  override def getResult():Double = 0.0
 }
 
 /**
@@ -76,13 +69,6 @@ class ClusteringSeparationEvaluator extends Evaluator {
       }
       centr.map{case (k,c,s)=>s*pow(c.in.distanceTo(centrAll.in),2)}
     }).reduce(_+_).map(x=>"SSB=%.5f".format(x))
-
-  /**
-   * Get the evaluation result.
-   *
-   * @return a Double containing the evaluation result
-   */
-  override def getResult():Double = 0.0
 }
 
 /**

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/Evaluator.scala
@@ -21,12 +21,19 @@ import java.io.Serializable
 
 import com.github.javacliparser.Configurable
 import org.apache.spark.streamdm.core.Example
+import org.apache.spark.streamdm.core.specification.ExampleSpecification
 import org.apache.spark.streaming.dstream.DStream
 
 /**
  * Abstract class which defines the operations needed to evaluate learners.
  */
 abstract class Evaluator extends Configurable with Serializable{
+
+  var exampleLearnerSpecification: ExampleSpecification = null
+
+  def setExampleSpecification(exampleSpecification: ExampleSpecification) = {
+    exampleLearnerSpecification = exampleSpecification
+  }
 
   /**
    * Process the result of a predicted stream of Examples and Doubles.
@@ -44,11 +51,4 @@ abstract class Evaluator extends Configurable with Serializable{
   def header(): String = {
     ""
   }
-
-  /**
-   * Get the evaluation result.
-   *
-   * @return a Double containing the evaluation result
-   */
-  def getResult(): Double
 }

--- a/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streamDMJob.scala
@@ -46,7 +46,6 @@ object streamDMJob {
         paramsArgs = paramsArgs.drop(1)
       }
     }
-    println("BatchInterval: " + batchInterval + " ms")
 
     val ssc = new StreamingContext(conf, Milliseconds(batchInterval))
 

--- a/src/main/scala/org/apache/spark/streamdm/streams/FileReader.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/FileReader.scala
@@ -19,8 +19,6 @@ package org.apache.spark.streamdm.streams
 
 import java.io.File
 import scala.io.Source
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Random
 
 import org.apache.spark.Logging
 import org.apache.spark.rdd.RDD
@@ -31,7 +29,6 @@ import com.github.javacliparser.{ IntOption, FloatOption, StringOption, FileOpti
 
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.core.specification._
-import org.apache.spark.streamdm.streams.generators.Generator
 
 /**
   * FileReader is used to read data from one file of full data to simulate a stream data.
@@ -81,7 +78,7 @@ class FileReader extends StreamReader with Logging {
       val file = new File(fileName)
       if (!file.exists()) {
         logError("file does not exists, input a new file name")
-        exit()
+        sys.exit()
       }
       headFileName = fileNameOption.getValue() + "." +
         dataHeadTypeOption.getValue + ".head"
@@ -132,7 +129,6 @@ class FileReader extends StreamReader with Logging {
       line = lines.next()
     }
     if (!hasHeadFile) {
-      //logInfo("UUUU" + line)
       if ("arff".equalsIgnoreCase(dataHeadTypeOption.getValue())) {
         exp = ExampleParser.fromArff(line, spec)
       } else {
@@ -173,12 +169,10 @@ class FileReader extends StreamReader with Logging {
         counter = counter + 1
         val limit = instanceLimitOption.getValue/ chunkSizeOption.getValue
         if(counter > limit){
-          println("Over limit instances. STOP!" )
           logInfo("Over limit instances. STOP!" )
           ssc.stop(stopSparkContext = false, stopGracefully = false)
         }
         Some(examplesRDD)
-
       }
 
       override def slideDuration = {

--- a/src/main/scala/org/apache/spark/streamdm/streams/PrintStreamWriter.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/PrintStreamWriter.scala
@@ -37,7 +37,7 @@ class PrintStreamWriter extends StreamWriter{
    */
   def output(stream: DStream[String]) = {
     stream.foreachRDD(rdd => {
-      rdd.foreach(x => {println(x)})
+      rdd.collect().foreach(x => println(x))
     })
   }
 

--- a/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
@@ -64,6 +64,7 @@ class EvaluatePrequential extends Task {
     learner.init(reader.getExampleSpecification())
 
     val evaluator:Evaluator = this.evaluatorOption.getValue()
+    evaluator.setExampleSpecification(reader.getExampleSpecification())
 
     val writer:StreamWriter = this.resultsWriterOption.getValue()
 


### PR DESCRIPTION
The core change is the addition of evaluation metrics for multiclass classification problems. Other ad hoc changes were added, such as removing some debug println(…) messages that were outputted to the results file. Further details about the changes can be found below as well as the tests to verify the evaluation metrics implemented. 

## DenseInstance.scala and SparseInstance.scala
* Previously in `def apply(index: Int): Double` 0.0 was returned when the index was invalid or did not exist. However, it is more appropriate to return NaN as 0.0 can be interpreted as a valid value. 

## ClusteringEvaluator.scala, Evaluator.scala and BasicClassificationEvaluator.scala
* Removed method `def getResults()` which only had a placeholder implementation. 
* Included ExampleSpecification attribute
* More about the changes in the BasicClassificationEvaluator.scala are present in a separate section

## streamDMJob.scala
* Removed debug println(…)

## FileReader.scala
* Removed debug println(…) and unused imports

## EvaluatePrequential.scala
* EvaluatePrequential is now setting the ExampleSpecification. Access to ExampleSpecification is useful for Evaluator derived classes as they can, for example, infer the number of classes in the problem. 

## BasicClassificationEvaluator.scala
* Add several multiclass evaluation metrics implementations (e.g. precision, recall, …). 
* There is now a specific header for multiclass problems. 
* Two new Options were added to control whether or not the _per class_ statistics and/or the confusion matrix are added to the output (these options do not apply to binary problems). 
* The ExampleSpecification attribute is used to discover the number of classes of the problem. 


## Tests
These tests use the normalized cover type dataset. Instructions to obtain the dataset and prepare for the tests: 
1. Download it from here: https://github.com/hmgomes/AdaptiveRandomForest/blob/master/COVT.arff.zip
2. Move it to `../data` under the streamDM project directory.  

OUTPUT: Avg statistics + per class statistics + confusion matrix (full output)
`./spark.sh "200 EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/covtypeNorm.arff -k 5810 -d 10 -i 581012) -e (BasicClassificationEvaluator) -h"  1> result_COVT.txt 2> log_COVT.log`

OUTPUT: Avg statistics + confusion matrix (no per class statistics)
`./spark.sh "200 EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/covtypeNorm.arff -k 5810 -d 10 -i 581012) -e (BasicClassificationEvaluator -c) -h"  1> result_COVT_noPerclass.txt 2> log_COVT_noPerclass.log`

OUTPUT: Avg statistics + per class statistics (no confusion matrix)
`./spark.sh "200 EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/covtypeNorm.arff -k 5810 -d 10 -i 581012) -e (BasicClassificationEvaluator -m) -h"  1> result_COVT_noConfMat.txt 2> log_COVT_noConfMat.log`

OUTPUT: Avg statistics only
`./spark.sh "200 EvaluatePrequential  -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/covtypeNorm.arff -k 5810 -d 10 -i 581012) -e (BasicClassificationEvaluator -c -m) -h"  1> result_COVT_onlyAvg.txt 2> log_COVT_onlyAvg.log`
