### PR TITLE
StreamDM-81: Update to Spark 2.2.0

### DIFF
--- a/learn.sbt
+++ b/learn.sbt
@@ -2,10 +2,10 @@ name := "streamDM (Spark Streaming)"
 
 version := "0.2"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "1.5.1"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.2.0"
 
-libraryDependencies += "org.apache.spark" % "spark-streaming_2.10" % "1.5.1"
+libraryDependencies += "org.apache.spark" % "spark-streaming_2.10" % "2.2.0"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
 
-libraryDependencies += "org.apache.spark" % "spark-streaming-kafka_2.10" % "1.5.1"
+libraryDependencies += "org.apache.spark" % "spark-streaming-kafka_2.10" % "1.6.3"

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/PerceptronLearner.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/PerceptronLearner.scala
@@ -17,11 +17,7 @@
 
 package org.apache.spark.streamdm.classifiers
 
-import com.github.javacliparser.{ClassOption, FloatOption, IntOption}
-import org.apache.spark.streamdm._
-import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.classifiers.model._
-import org.apache.spark.streaming.dstream._
 
 /** The PerceptronLearner trains a LinearModel which is a perceptron. It
  * currently is implemented as an SGDLearner with a PerceptronLoss function.

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/SGDLearner.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/SGDLearner.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.streamdm.classifiers
 
-import org.apache.spark.streamdm._
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.classifiers.model._
 import org.apache.spark.streaming.dstream._

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/bayes/MultinomialNaiveBayes.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/bayes/MultinomialNaiveBayes.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streamdm.classifiers.bayes
 
-import scala.math.{ log, log10 }
+import scala.math.log10
 import com.github.javacliparser.IntOption
 import org.apache.spark.streaming.dstream._
 import org.apache.spark.streamdm.classifiers.Classifier
@@ -136,7 +136,7 @@ class MultinomialNaiveBayesModel(val numClasses: Int, val numFeatures: Int,
   /**
    * Update the model, depending on the Instance given for training.
    *
-   * @param change the example based on which the Model is updated
+   * @param instance the example based on which the Model is updated
    * @return the updated Model
    */
   override def update(instance: Example): MultinomialNaiveBayesModel = {

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/HingeLoss.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/HingeLoss.scala
@@ -23,7 +23,7 @@ package org.apache.spark.streamdm.classifiers.model
 
 class HingeLoss extends Loss with Serializable {
   /** Computes the value of the loss function
-   * @param value the label against which the loss is computed   
+   * @param label the label against which the loss is computed
    * @param dot the dot product of the linear model and the instance
    * @return the loss value 
    */
@@ -34,7 +34,7 @@ class HingeLoss extends Loss with Serializable {
   }
 
   /** Computes the value of the gradient function
-   * @param value the label against which the gradient is computed   
+   * @param label the label against which the gradient is computed
    * @param dot the dot product of the linear model and the instance
    * @return the gradient value 
    */

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/L1Regularizer.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/L1Regularizer.scala
@@ -23,7 +23,7 @@ package org.apache.spark.streamdm.classifiers.model
  */
 class L1Regularizer extends Regularizer with Serializable {
   /** Computes the value of the gradient function
-   * @param value the weight for which the gradient is computed   
+   * @param weight the weight for which the gradient is computed
    * @return the gradient value 
    */
   def gradient(weight: Double): Double = if (weight>=0) 1.0 else -1.0

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/L2Regularizer.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/L2Regularizer.scala
@@ -23,7 +23,7 @@ package org.apache.spark.streamdm.classifiers.model
  */
 class L2Regularizer extends Regularizer with Serializable {
   /** Computes the value of the gradient function
-   * @param value the weight for which the gradient is computed   
+   * @param valweightue the weight for which the gradient is computed
    * @return the gradient value 
    */
   def gradient(weight: Double): Double = weight 

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/LogisticLoss.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/LogisticLoss.scala
@@ -17,15 +17,13 @@
 
 package org.apache.spark.streamdm.classifiers.model
 
-import scala.math
-
 /**
  * Implementation of the logistic loss function.
  */
 
 class LogisticLoss extends Loss with Serializable {
   /** Computes the value of the loss function
-   * @param value the label against which the loss is computed   
+   * @param label the label against which the loss is computed
    * @param dot the dot product of the linear model and the instance
    * @return the loss value 
    */
@@ -35,7 +33,7 @@ class LogisticLoss extends Loss with Serializable {
   }
 
   /** Computes the value of the gradient function
-   * @param value the label against which the gradient is computed   
+   * @param label the label against which the gradient is computed
    * @param dot the dot product of the linear model and the instance
    * @return the gradient value 
    */

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/Loss.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/Loss.scala
@@ -23,14 +23,14 @@ package org.apache.spark.streamdm.classifiers.model
  */
 trait Loss extends Serializable {
   /** Computes the value of the loss function
-   * @param value the label against which the loss is computed   
+   * @param label the label against which the loss is computed
    * @param dot the dot product of the linear model and the instance
    * @return the loss value 
    */
   def loss(label: Double, dot: Double): Double
 
   /** Computes the value of the gradient function
-   * @param value the label against which the gradient is computed   
+   * @param label the label against which the gradient is computed
    * @param dot the dot product of the linear model and the instance
    * @return the gradient value 
    */

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/PerceptronLoss.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/PerceptronLoss.scala
@@ -24,7 +24,7 @@ package org.apache.spark.streamdm.classifiers.model
 
 class PerceptronLoss extends SquaredLoss with Serializable {
   /** Computes the value of the perceptron update function
-   * @param value the label against which the update is computed   
+   * @param label the label against which the update is computed
    * @param dot the dot product of the linear model and the instance
    * @return the update value 
    */

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/Regularizer.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/Regularizer.scala
@@ -23,7 +23,7 @@ package org.apache.spark.streamdm.classifiers.model
  */
 trait Regularizer extends Serializable {
   /** Computes the value of the gradient function
-   * @param value the weight for which the gradient is computed   
+   * @param weight the weight for which the gradient is computed
    * @return the gradient value 
    */
   def gradient(weight: Double): Double

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/SquaredLoss.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/SquaredLoss.scala
@@ -23,7 +23,7 @@ package org.apache.spark.streamdm.classifiers.model
 
 class SquaredLoss extends Loss with Serializable {
   /** Computes the value of the loss function
-   * @param value the label against which the loss is computed   
+   * @param label the label against which the loss is computed
    * @param dot the dot product of the linear model and the instance
    * @return the loss value 
    */
@@ -31,7 +31,7 @@ class SquaredLoss extends Loss with Serializable {
     0.5*(dot-label)*(dot-label)
 
   /** Computes the value of the gradient function
-   * @param value the label against which the gradient is computed   
+   * @param label the label against which the gradient is computed
    * @param dot the dot product of the linear model and the instance
    * @return the gradient value 
    */

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/model/ZeroRegularizer.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/model/ZeroRegularizer.scala
@@ -22,7 +22,7 @@ package org.apache.spark.streamdm.classifiers.model
  */
 class ZeroRegularizer extends Regularizer with Serializable {
   /** Computes the value of the gradient function
-   * @param value the weight for which the gradient is computed   
+   * @param weight the weight for which the gradient is computed
    * @return the gradient value 
    */
   def gradient(weight: Double): Double = 0.0

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/ConditionalTest.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/ConditionalTest.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streamdm.classifiers.trees
 
-import org.apache.spark.streamdm.core.{ Example }
+import org.apache.spark.streamdm.core.Example
 
 /**
  * ConditionalTest is an abstract class for  conditional tests, used for

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/FeatureClassObserver.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/FeatureClassObserver.scala
@@ -19,8 +19,7 @@ package org.apache.spark.streamdm.classifiers.trees
 
 import scala.collection.mutable.TreeSet
 import scala.math.{ min, max }
-import org.apache.spark.Logging
-import org.apache.spark.streamdm.core._
+import org.apache.spark.internal.Logging
 import org.apache.spark.streamdm.core.specification._
 import org.apache.spark.streamdm.utils.Utils.{ normal, transpose, splitTranspose }
 /**

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/HoeffdingTree.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/HoeffdingTree.scala
@@ -21,10 +21,10 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.HashSet
 import scala.math.{ log => math_log, sqrt }
 import scala.collection.mutable.Queue
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import com.github.javacliparser._
 import org.apache.spark.streaming.dstream._
-import org.apache.spark.streamdm.utils.Utils.{ argmax }
+import org.apache.spark.streamdm.utils.Utils.argmax
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.classifiers._
 import org.apache.spark.streamdm.core.specification.ExampleSpecification

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/Node.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/Node.scala
@@ -18,14 +18,12 @@
 package org.apache.spark.streamdm.classifiers.trees
 
 import scala.collection.mutable.ArrayBuffer
-import scala.math.{ max }
-
-import org.apache.spark.Logging
+import scala.math.max
 
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.core.specification._
 import org.apache.spark.streamdm.classifiers.bayes._
-import org.apache.spark.streamdm.utils.Utils.{ argmax }
+import org.apache.spark.streamdm.utils.Utils.argmax
 
 /**
  * Abstract class containing the node information for the Hoeffding trees.
@@ -412,7 +410,7 @@ class InactiveLearningNode(classDistribution: Array[Double])
   /**
    * Merge two nodes
    *
-   * @param node the node which will be merged
+   * @param that the node which will be merged
    * @param trySplit flag indicating whether the node will be split
    * @return new node
    */

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/SplitCriterion.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/SplitCriterion.scala
@@ -17,9 +17,9 @@
 
 package org.apache.spark.streamdm.classifiers.trees
 
-import scala.math.{ max,min }
+import scala.math.max
 
-import org.apache.spark.streamdm.utils.Utils.{log2}
+import org.apache.spark.streamdm.utils.Utils.log2
 
 trait SplitCriterionType
 

--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/Utils.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/Utils.scala
@@ -16,7 +16,8 @@
  */
 package org.apache.spark.streamdm.classifiers.trees
 
-import scala.math.{ max, min }
+import scala.math.min
+
 object Utils {
   /*
    * Add two arrays and return the min length of two input arrays.

--- a/src/main/scala/org/apache/spark/streamdm/clusterers/StreamKM.scala
+++ b/src/main/scala/org/apache/spark/streamdm/clusterers/StreamKM.scala
@@ -20,13 +20,8 @@ package org.apache.spark.streamdm.clusterers
 import org.apache.spark.streamdm.clusterers.clusters._
 import org.apache.spark.streamdm.clusterers.utils._
 import org.apache.spark.streamdm.core._
-import org.apache.spark.streamdm.tasks._
-import org.apache.spark._
 import org.apache.spark.streaming.dstream._
 import com.github.javacliparser._
-import org.apache.spark.streaming._
-import org.apache.spark.streaming.StreamingContext._
-import com.github.javacliparser.ClassOption
 import org.apache.spark.streamdm.core.specification.ExampleSpecification
 
 /**

--- a/src/main/scala/org/apache/spark/streamdm/clusterers/clusters/BucketManager.scala
+++ b/src/main/scala/org/apache/spark/streamdm/clusterers/clusters/BucketManager.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.streamdm.clusterers.clusters
 
 import org.apache.spark.streamdm.core._
-import scala.math
 import scala.collection.mutable.Queue
 import scala.util.control.Breaks._
 

--- a/src/main/scala/org/apache/spark/streamdm/clusterers/clusters/MicroCluster.scala
+++ b/src/main/scala/org/apache/spark/streamdm/clusterers/clusters/MicroCluster.scala
@@ -19,8 +19,6 @@ package org.apache.spark.streamdm.clusterers.clusters
 
 import org.apache.spark.streamdm.core._
 
-import math._
-
 /**
  * A MicroCluster contains the underlying structure for the Clustream processing
  * framework, and summarizes a number of instances belonging to the same

--- a/src/main/scala/org/apache/spark/streamdm/clusterers/clusters/TreeCoreset.scala
+++ b/src/main/scala/org/apache/spark/streamdm/clusterers/clusters/TreeCoreset.scala
@@ -20,7 +20,6 @@ package org.apache.spark.streamdm.clusterers.clusters
 import org.apache.spark.streamdm.core._
 
 import scala.util.Random
-import scala.io.Source
 
 /**
  * A TreeCoreset contains the underlying tree structure for the coreset

--- a/src/main/scala/org/apache/spark/streamdm/core/DenseInstance.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/DenseInstance.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.streamdm.core
 
-import math._
-
 /**
  * A DenseInstance is an Instance in which the features are dense, i.e., there
  * exists a value for (almost) every feature.

--- a/src/main/scala/org/apache/spark/streamdm/core/ExampleParser.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/ExampleParser.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streamdm.core
 
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.streamdm.core.specification._
 
 /*

--- a/src/main/scala/org/apache/spark/streamdm/core/Learner.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/Learner.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.streamdm.core
 
-import org.apache.spark.streamdm.core._
 import org.apache.spark.streaming.dstream._
 import com.github.javacliparser.Configurable
 import org.apache.spark.streamdm.core.specification.ExampleSpecification

--- a/src/main/scala/org/apache/spark/streamdm/core/specification/SpecificationParser.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/specification/SpecificationParser.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.streamdm.core.specification
 
 import scala.io.Source
-import org.apache.spark.Logging
-import org.apache.spark.streamdm.classifiers.trees.Utils.{ arraytoString }
+import org.apache.spark.internal.Logging
+import org.apache.spark.streamdm.classifiers.trees.Utils.arraytoString
 
 /*
  * class SpecificationParser helps to generate head for data

--- a/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/evaluation/BasicClassificationEvaluator.scala
@@ -20,7 +20,7 @@ package org.apache.spark.streamdm.evaluation
 import java.io.Serializable
 
 import com.github.javacliparser.FlagOption
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.streamdm.core.specification.ExampleSpecification
 import com.github.javacliparser.FloatOption
 import org.apache.spark.streamdm.core.Example

--- a/src/main/scala/org/apache/spark/streamdm/streams/FileReader.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/FileReader.scala
@@ -20,12 +20,12 @@ package org.apache.spark.streamdm.streams
 import java.io.File
 import scala.io.Source
 
-import org.apache.spark.Logging
+import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.dstream.{ DStream, InputDStream }
 import org.apache.spark.streaming.{ Time, Duration, StreamingContext }
 
-import com.github.javacliparser.{ IntOption, FloatOption, StringOption, FileOption }
+import com.github.javacliparser.{ IntOption, StringOption}
 
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.core.specification._

--- a/src/main/scala/org/apache/spark/streamdm/streams/PrintStreamWriter.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/PrintStreamWriter.scala
@@ -17,11 +17,7 @@
 
 package org.apache.spark.streamdm.streams
 
-import com.github.javacliparser._
-import org.apache.spark.streamdm.core._
-import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streamdm.core.Instance
 
 /**
  * Stream writer that outputs the stream to the standard output.

--- a/src/main/scala/org/apache/spark/streamdm/streams/SocketTextStreamReader.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/SocketTextStreamReader.scala
@@ -17,13 +17,11 @@
 
 package org.apache.spark.streamdm.streams
 
-import com.github.javacliparser.{ StringOption, IntOption, ClassOption }
-import org.apache.spark.streamdm.core._
+import com.github.javacliparser.{ StringOption, IntOption }
 import org.apache.spark.streamdm.core.specification._
 import org.apache.spark.streamdm.core.Example
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream
-import org.apache.spark.streamdm.core.Instance
 import org.apache.spark.streamdm.core.specification.ExampleSpecification
 
 /**

--- a/src/main/scala/org/apache/spark/streamdm/streams/StreamReader.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/StreamReader.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.streamdm.streams
 
-import org.apache.spark.streamdm.core.{Example}
+import org.apache.spark.streamdm.core.Example
 import org.apache.spark.streamdm.core.specification.ExampleSpecification
 import org.apache.spark.streaming.StreamingContext
 import org.apache.spark.streaming.dstream.DStream

--- a/src/main/scala/org/apache/spark/streamdm/streams/generators/Cluster.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/generators/Cluster.scala
@@ -18,8 +18,6 @@
 package org.apache.spark.streamdm.streams.generators
 
 import scala.collection.mutable.HashMap
-import scala.collection.mutable.StringBuilder
-import java.lang.String
 import org.apache.spark.streamdm.core.Instance
 import scala.util.Random
 
@@ -51,7 +49,7 @@ abstract class Cluster {
    * Returns the probability of the given point belonging to
    * this cluster.
    *
-   * @param point
+   * @param instance
    * @return a value between 0 and 1
    */
   def getInclusionProbability(instance: Instance): Double

--- a/src/main/scala/org/apache/spark/streamdm/streams/generators/Generator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/generators/Generator.scala
@@ -20,7 +20,6 @@ package org.apache.spark.streamdm.streams.generators
 import org.apache.spark.rdd.RDD
 import org.apache.spark.streaming.{ Duration, Time, StreamingContext }
 import org.apache.spark.streaming.dstream.{ InputDStream, DStream }
-import com.github.javacliparser.IntOption
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.streams.StreamReader
 

--- a/src/main/scala/org/apache/spark/streamdm/streams/generators/HyperplaneGenerator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/generators/HyperplaneGenerator.scala
@@ -17,12 +17,8 @@
 package org.apache.spark.streamdm.streams.generators
 
 import com.github.javacliparser.IntOption
-import org.apache.spark.rdd.RDD
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.core.specification._
-import org.apache.spark.streamdm.streams.StreamReader
-import org.apache.spark.streaming.{ Duration, Time, StreamingContext }
-import org.apache.spark.streaming.dstream.{ InputDStream, DStream }
 import scala.util.Random
 import org.apache.spark.streamdm.core.specification.ExampleSpecification
 

--- a/src/main/scala/org/apache/spark/streamdm/streams/generators/RandomRBFEventsGenerator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/generators/RandomRBFEventsGenerator.scala
@@ -16,14 +16,9 @@
  */
 package org.apache.spark.streamdm.streams.generators
 
-import org.apache.spark.streamdm.streams.StreamReader
-import com.github.javacliparser.{ IntOption, FloatOption, FlagOption, StringOption }
-import org.apache.spark.rdd.RDD
+import com.github.javacliparser.{ IntOption, FloatOption, FlagOption }
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.core.specification._
-import org.apache.spark.streamdm.streams.StreamReader
-import org.apache.spark.streaming.{ Duration, Time, StreamingContext }
-import org.apache.spark.streaming.dstream.{ InputDStream, DStream }
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 import scala.math._

--- a/src/main/scala/org/apache/spark/streamdm/streams/generators/RandomRBFGenerator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/generators/RandomRBFGenerator.scala
@@ -17,16 +17,10 @@
 
 package org.apache.spark.streamdm.streams.generators
 
-import com.github.javacliparser.{ IntOption, FloatOption, StringOption }
-import org.apache.spark.streaming.dstream.{ DStream, InputDStream }
-import org.apache.spark.streaming.{ Time, Duration, StreamingContext }
-import org.apache.spark.rdd.RDD
+import com.github.javacliparser.IntOption
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.core.specification._
-import org.apache.spark.streamdm.streams.StreamReader
-import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
-import scala.io._
 import java.io._
 import org.apache.spark.streamdm.core.specification.ExampleSpecification
 

--- a/src/main/scala/org/apache/spark/streamdm/streams/generators/RandomTreeGenerator.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/generators/RandomTreeGenerator.scala
@@ -18,17 +18,10 @@ package org.apache.spark.streamdm.streams.generators
 
 import scala.collection.immutable.List
 import scala.util.Random
-
-import org.apache.spark.Logging
-import org.apache.spark.rdd.RDD
-import org.apache.spark.streaming.{ Duration, Time, StreamingContext }
-import org.apache.spark.streaming.dstream.{ InputDStream, DStream }
-
+import org.apache.spark.internal.Logging
 import com.github.javacliparser.{ IntOption, FloatOption }
-
 import org.apache.spark.streamdm.core._
 import org.apache.spark.streamdm.core.specification._
-import org.apache.spark.streamdm.streams.StreamReader
 
 /**
  * Stream generator for generating data from a randomly generated tree.
@@ -92,7 +85,7 @@ class RandomTreeGenerator extends Generator with Logging {
     "The fraction of leaves per level from firstLeafLevel onwards.",
     0.15, 0.0, 1.0)
 
-  var treeRoot: Node = null
+  var treeRoot: Node = _
 
   /**
    * returns chunk size
@@ -209,7 +202,7 @@ class RandomTreeGenerator extends Generator with Logging {
         val splitFeatureIndex = this.numNominalsOption.getValue() + numericIndex;
         val minVal = minNumericVals(numericIndex);
         val maxVal = maxNumericVals(numericIndex);
-        val splitFeatureValue = ((maxVal - minVal) * Random.nextDouble())
+        val splitFeatureValue = (maxVal - minVal) * Random.nextDouble()
         +minVal;
         val node = new BranchNode(splitFeatureIndex, 2, splitFeatureValue)
         val newMaxVals = maxNumericVals.clone()

--- a/src/main/scala/org/apache/spark/streamdm/streams/generators/SphereCluster.scala
+++ b/src/main/scala/org/apache/spark/streamdm/streams/generators/SphereCluster.scala
@@ -30,9 +30,9 @@ class SphereCluster extends Cluster {
 
   def this(center: Array[Double], radius: Double, weightedSize: Double) {
     this()
-    this.center = center;
-    this.radius = radius;
-    this.weight = weightedSize;
+    this.center = center
+    this.radius = radius
+    this.weight = weightedSize
   }
 
   def this(center: Array[Double], radius: Double) {
@@ -85,7 +85,7 @@ class SphereCluster extends Cluster {
 
   def combine(cluster: SphereCluster): Unit = {
     var center: Array[Double] = getCenter()
-    var newcenter: Array[Double] = new Array[Double](center.length)
+    val newcenter: Array[Double] = new Array[Double](center.length)
     val other_center: Array[Double] = cluster.getCenter()
     val other_weight: Double = cluster.getWeight()
     val other_radius: Double = cluster.getRadius()
@@ -138,7 +138,7 @@ class SphereCluster extends Cluster {
 
   @Override
   def getCenter(): Array[Double] = {
-    var copy: Array[Double] = new Array[Double](center.length)
+    val copy: Array[Double] = new Array[Double](center.length)
     Array.copy(center, 0, copy, 0, center.length)
     copy
   }
@@ -177,7 +177,7 @@ class SphereCluster extends Cluster {
     //get the center through getCenter so subclass have a chance
     val center: Array[Double] = getCenter()
     for (i <- 0 until center.length) {
-      var d: Double = center(i) - instance(i)
+      val d: Double = center(i) - instance(i)
       distance += d * d
     }
     Math.sqrt(distance)


### PR DESCRIPTION
## Summary of the changes
The changes in this pull request were made to update streamDM to the current Spark version, i.e., `Spark 2.2.0`. 

Most classes in the framework were touched by this request, mostly on the import section. Unused imports were removed as well. Other small changes were performed as well, since all classes were revisited, such as opportunities to use `val` instead of `var`. 

`sbt.learn` was also updated to include the new versions for the existing dependencies. 

## Tests
Just a sanity check to verify if the code is working with the latest version. 
The test uses the electNormNew.arff, which is inside `\data` directory, so there is no need to include other dataset.  

1. Execute EvaluatePrequential using electNormNew.arff

Run the command:
```
./spark.sh "200 EvaluatePrequential -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/electNormNew.arff -k 1000 -d 10 -i 10000) -e (BasicClassificationEvaluator -c -m) -h" 1> result_ELEC.txt 2> log_ELEC.log
```
Expected output:
10 rows of statistics in results_ELEC.txt