### PR TITLE
StreamDM-84: Updates to Bagging

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/classifiers/meta/Bagging.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/meta/Bagging.scala
@@ -42,7 +42,7 @@ class Bagging extends Classifier {
   type T = LinearModel
 
   val baseClassifierOption: ClassOption = new ClassOption("baseClassifier", 'l',
-    "Base Classifier to use", classOf[Classifier], "SGDLearner")
+    "Base Classifier to use", classOf[Classifier], "trees.HoeffdingTree")
 
   val ensembleSizeOption: IntOption = new IntOption("ensembleSize", 's',
     "The number of models in the bag.", 10, 1, Integer.MAX_VALUE)
@@ -120,6 +120,4 @@ class Bagging extends Classifier {
     if (exampleLearnerSpecification == null) 2
     else exampleLearnerSpecification.out(0).range
   }
-
-
 }

--- a/src/main/scala/org/apache/spark/streamdm/core/ClassificationModel.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/ClassificationModel.scala
@@ -24,7 +24,7 @@ package org.apache.spark.streamdm.core
  */
 trait ClassificationModel extends Model {
 
-  /* Predict the label of the Instance, given the current Model
+  /** Predict the label of the Instance, given the current Model
    *
    * @param instance the Instance which needs a class predicted
    * @return a Double representing the class predicted
@@ -33,10 +33,9 @@ trait ClassificationModel extends Model {
 
   /** Computes the probability for a given label class, given the current Model
     *
-    * @param instance the Instance which needs a class predicted
+    * @param example the Example which needs a class predicted
     * @return the predicted probability
     */
-
-  def prob(instance: Example): Double
+  def prob(example: Example): Double
 
 }


### PR DESCRIPTION
## Summary of the changes
Update the Bagging implementation to use Hoeffding Trees as its base learner. 
In addition, the default base learner was also set to trees.HoeffdingTrees in Bagging. This makes the Bagging implementation closer to the current default implementation in MOA (see [OzaBag.java](https://github.com/Waikato/moa/blob/master/moa/src/main/java/moa/classifiers/meta/OzaBag.java)). 


### Classes affected by the changes
#### Bagging
Changed its default learner. 

#### HoeffdingTreeModel
Included the implementation of `proba(example: Example): Double` as HoeffdingTreeModel now extends `ClassificationModel` instead of `Model`. 
This allows using HoeffdingTree as a base learner for Bagging. 

#### ClassificationModel
Updated the documentation (i.e. changed from Instance to Example)


## Tests
1. Explicitly defining the base learner as the HoeffdingTree. 
* Run: 
```
./spark.sh "200 EvaluatePrequential -l (meta.Bagging -l trees.HoeffdingTree) -s (FileReader -f ../data/elecNormNew.arff -k 4532 -d 10 -i 45312) -e (BasicClassificationEvaluator -c -m) -h" 1> result_elec.txt 2> log_elec.log
```
* Output: results_elec.txt should contain the classification performance results. 

2. Implicitly using HoeffdingTree as the base learner for Bagging. 
* Run: 
```
./spark.sh "200 EvaluatePrequential -l meta.Bagging -s (FileReader -f ../data/elecNormNew.arff -k 4532 -d 10 -i 45312) -e (BasicClassificationEvaluator -c -m) -h" 1> result_elec.txt 2> log_elec.log
```
* Output: results_elec.txt should contain the classification performance results. 