### PR TITLE
StreamDM-86: Adding runtime estimation to BasicClassificationEvaluator

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/classifiers/trees/HoeffdingTree.scala
+++ b/src/main/scala/org/apache/spark/streamdm/classifiers/trees/HoeffdingTree.scala
@@ -375,7 +375,7 @@ class HoeffdingTreeModel(val espec: ExampleSpecification, val numericObserverTyp
         listExamples = new ArrayBuffer[Example]()
       }
       else{
-        println("|| Tree's height exceeds maxDepth! ||")
+        logInfo("Tree's height exceeds maxDepth")
         listExamples = new ArrayBuffer[Example]()
       }
 

--- a/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.streamdm.tasks
 
 import com.github.javacliparser._
-import org.apache.spark.internal.Logging
 import org.apache.spark.streamdm.classifiers._
 import org.apache.spark.streamdm.streams._
 import org.apache.spark.streaming.StreamingContext
@@ -36,7 +35,7 @@ import org.apache.spark.streamdm.evaluation.Evaluator
  *  <li> Writer (<b>-w</b>), a writer object of type <tt>StreamWriter</tt>
  * </ul>
  */
-class EvaluatePrequential extends Task with Logging {
+class EvaluatePrequential extends Task {
 
   val learnerOption:ClassOption = new ClassOption("learner", 'l',
     "Learner to use", classOf[Classifier], "SGDLearner")
@@ -74,8 +73,6 @@ class EvaluatePrequential extends Task with Logging {
     if(shouldPrintHeaderOption.isSet) {
       writer.output(evaluator.header())
     }
-
-    logInfo("run evaluate prequential")
 
     //Predict
     val predPairs = learner.predict(instances)

--- a/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/EvaluatePrequential.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.streamdm.tasks
 
 import com.github.javacliparser._
+import org.apache.spark.internal.Logging
 import org.apache.spark.streamdm.classifiers._
 import org.apache.spark.streamdm.streams._
 import org.apache.spark.streaming.StreamingContext
@@ -35,7 +36,7 @@ import org.apache.spark.streamdm.evaluation.Evaluator
  *  <li> Writer (<b>-w</b>), a writer object of type <tt>StreamWriter</tt>
  * </ul>
  */
-class EvaluatePrequential extends Task {
+class EvaluatePrequential extends Task with Logging {
 
   val learnerOption:ClassOption = new ClassOption("learner", 'l',
     "Learner to use", classOf[Classifier], "SGDLearner")
@@ -73,6 +74,8 @@ class EvaluatePrequential extends Task {
     if(shouldPrintHeaderOption.isSet) {
       writer.output(evaluator.header())
     }
+
+    logInfo("run evaluate prequential")
 
     //Predict
     val predPairs = learner.predict(instances)


### PR DESCRIPTION
## Summary of the changes
This pull request addresses #86. 

#### BasicClassificationEvaluator
Added the column _Runtime_ to the output. Currently using `System.nanoTime()` for a rough estimation of runtime. 

#### HoeffdingTree
Changed the output of a log message (now using `logInfo()`). 

## Tests
Using datasets elecNormNew.arff and covtypeNorm.arff. 

1. Verify output of a binary classification problem (elecNormNew)
 * Run: 
`./spark.sh "200 EvaluatePrequential -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o)-s (FileReader -f ../data/elecNormNew.arff -k 454 -d 10 -i 45312) -e (BasicClassificationEvaluator -c -m) -h" 1> results_binary.txt 2> log_binary.log`

 * Output: results_binary.txt should contain the classification performance results, including the Runtime column. 

2. Explicitly defining the base learner as the HoeffdingTree. 
 * Run: 
`./spark.sh "200 EvaluatePrequential -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/covtypeNorm.arff -k 5810 -d 10 -i 581012) -e (BasicClassificationEvaluator -c -m) -h" 1> results_multiclass.txt 2> log_multiclass.log`

 * Output: results_multiclass.txt should contain the classification performance results, including the Runtime column. 