### PR TITLE
StreamDM-97

### DIFF
--- a/src/main/scala/org/apache/spark/streamdm/clusterers/StreamKM.scala
+++ b/src/main/scala/org/apache/spark/streamdm/clusterers/StreamKM.scala
@@ -103,7 +103,6 @@ class StreamKM extends Clusterer {
 
       val assignedCl = clusters.foldLeft((0, Double.MaxValue, 0))(
         (cl, centr) => {
-
           val dist = centr.in.distanceTo(ex.in)
           if (dist < cl._2) ((cl._3, dist, cl._3 + 1))
           else ((cl._1, cl._2, cl._3 + 1))

--- a/src/main/scala/org/apache/spark/streamdm/tasks/ClusteringTrainEvaluate.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/ClusteringTrainEvaluate.scala
@@ -55,23 +55,7 @@ class ClusteringTrainEvaluate extends Task {
    * @param ssc The Spark Streaming context in which the task is run.
    */
   def run(ssc:StreamingContext): Unit = {
-    //check if clusterer is streamkm
-    if(this.clustererOption.getValue().toString.contains("StreamKM")){
-      val reader:StreamReader = this.streamReaderOption.getValue()
-
-      val clusterer: StreamKM = new StreamKM()
-      clusterer.init(reader.getExampleSpecification())
-
-      val evaluator:Evaluator = this.evaluatorOption.getValue()
-
-      val writer:StreamWriter = this.resultsWriterOption.getValue()
-
-      val instances = reader.getExamples(ssc)
-      //Train and assign
-      val clpairs = clusterer.trainStreamKM(instances)
-      writer.output(evaluator.addResult(clpairs))
-    }
-    else {
+  
     val reader:StreamReader = this.streamReaderOption.getValue()
 
     val clusterer: Clusterer = this.clustererOption.getValue()
@@ -91,6 +75,6 @@ class ClusteringTrainEvaluate extends Task {
     
     //Print statistics
     writer.output(evaluator.addResult(clpairs))
-    }
+    
   }
 }

--- a/src/main/scala/org/apache/spark/streamdm/tasks/ClusteringTrainEvaluate.scala
+++ b/src/main/scala/org/apache/spark/streamdm/tasks/ClusteringTrainEvaluate.scala
@@ -55,7 +55,23 @@ class ClusteringTrainEvaluate extends Task {
    * @param ssc The Spark Streaming context in which the task is run.
    */
   def run(ssc:StreamingContext): Unit = {
+    //check if clusterer is streamkm
+    if(this.clustererOption.getValue().toString.contains("StreamKM")){
+      val reader:StreamReader = this.streamReaderOption.getValue()
 
+      val clusterer: StreamKM = new StreamKM()
+      clusterer.init(reader.getExampleSpecification())
+
+      val evaluator:Evaluator = this.evaluatorOption.getValue()
+
+      val writer:StreamWriter = this.resultsWriterOption.getValue()
+
+      val instances = reader.getExamples(ssc)
+      //Train and assign
+      val clpairs = clusterer.trainStreamKM(instances)
+      writer.output(evaluator.addResult(clpairs))
+    }
+    else {
     val reader:StreamReader = this.streamReaderOption.getValue()
 
     val clusterer: Clusterer = this.clustererOption.getValue()
@@ -75,5 +91,6 @@ class ClusteringTrainEvaluate extends Task {
     
     //Print statistics
     writer.output(evaluator.addResult(clpairs))
+    }
   }
 }


### PR DESCRIPTION
## Summary of the changes
_Function train of StreamKM needs to be combined with the assign method, since data are lost between the calls.  Function trainStreamKM updates the bucketManager with the incoming input, then runs kmeans.cluster and assigns the input to the nearest cluster's index. To call trainStreamKM  "ClusteringTrainEvaluate" needs some changes as well._

### Classes that are affected
_StreamKM, ClusteringTrainEvaluate_

## Tests
_Run with command:_
`./spark.sh "ClusteringTrainEvaluate -c (StreamKM) -s (SocketTextStreamReader)" 1> result_iris_streamKM.txt 2> log_iris_streamKM.log
`