### PR TITLE
StreamDM-101: Update to Spark 2.3.2

### DIFF
--- a/learn.sbt
+++ b/learn.sbt
@@ -8,8 +8,6 @@ libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.2"
 
 libraryDependencies += "org.apache.spark" % "spark-streaming_2.11" % "2.3.2"
 
-libraryDependencies += "org.apache.spark" %% "spark-mllib" % "2.3.2"
-
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
 
 libraryDependencies += "org.apache.spark" % "spark-streaming-kafka_2.10" % "1.6.3"

--- a/learn.sbt
+++ b/learn.sbt
@@ -2,9 +2,13 @@ name := "streamDM (Spark Streaming)"
 
 version := "0.2"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.2.0"
+scalaVersion := "2.11.8"
 
-libraryDependencies += "org.apache.spark" % "spark-streaming_2.10" % "2.2.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.2"
+
+libraryDependencies += "org.apache.spark" % "spark-streaming_2.11" % "2.3.2"
+
+libraryDependencies += "org.apache.spark" %% "spark-mllib" % "2.3.2"
 
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % "test"
 

--- a/scripts/spark.sh
+++ b/scripts/spark.sh
@@ -1,5 +1,6 @@
+#!/usr/bin/env bash
 $SPARK_HOME/bin/spark-submit \
   --class "org.apache.spark.streamdm.streamDMJob" \
   --master local[2] \
-  ../target/scala-2.10/streamdm-spark-streaming-_2.10-0.2.jar \
+  ../target/scala-2.11/streamdm-spark-streaming-_2.11-0.2.jar \
   $1

--- a/src/main/scala/org/apache/spark/streamdm/core/NullInstance.scala
+++ b/src/main/scala/org/apache/spark/streamdm/core/NullInstance.scala
@@ -25,7 +25,7 @@ package org.apache.spark.streamdm.core
  * value of 0.
  */
 
-case class NullInstance extends Instance with Serializable {
+case class NullInstance() extends Instance with Serializable {
 
   type T = NullInstance
 


### PR DESCRIPTION
## Summary of the changes
The changes in this pull request were made to update streamDM to the current Spark version, i.e., `Spark 2.3.2`. It shall also works with Spark 2.3.1 and Spark 2.3. 

* Class src/main/scala/org/apache/spark/streamdm/core/**NullInstance.scala** was updated to address a small concern due to the Scala 2.11 version. 
* `sbt.learn` was updated to include the new versions for the existing dependencies. 
* If the log is outputted to stdout (by default it is) the result output file from the test command will contain both the results and the log. One way to avoid that is by explicitly setting the log4j.properties file in Spark home (just remove “template” from log4j.properties.template in /conf in the Spark diretory). 
* `spark.sh` was updated to point to the new Scala 2.11 jar file
* It was tested using Scala 2.11.8
* This is related to #102 

## Tests
Just a sanity check to verify if the code is working with the latest version. 
The test uses the electNormNew.arff, which is inside `\data` directory, so there is no need to download a dataset to run the experiment. 

1. Execute EvaluatePrequential using electNormNew.arff

Run the command:
```
./spark.sh "200 EvaluatePrequential -l (trees.HoeffdingTree -l 0 -t 0.05 -g 200 -o) -s (FileReader -f ../data/electNormNew.arff -k 1000 -d 10 -i 10000) -e (BasicClassificationEvaluator -c -m) -h" 1> result_ELEC.txt 2> log_ELEC.log
```
Expected output:
10 rows of statistics in results_ELEC.txt
